### PR TITLE
Fixed #23 ClientConfig differs between appservers

### DIFF
--- a/jaxrs/sse-producer/src/main/java/org/javaee8/jaxrs/sseproducer/data/EventData.java
+++ b/jaxrs/sse-producer/src/main/java/org/javaee8/jaxrs/sseproducer/data/EventData.java
@@ -2,7 +2,6 @@ package org.javaee8.jaxrs.sseproducer.data;
 
 import java.util.Date;
 import java.util.UUID;
-import javax.json.bind.JsonbBuilder;
 
 /**
  *
@@ -16,7 +15,7 @@ public class EventData {
 
     public EventData() {
     }
-    
+
     public EventData(String comment) {
         this.setTime(new Date());
         this.setId(UUID.randomUUID().toString());
@@ -45,10 +44,5 @@ public class EventData {
 
     public void setComment(String comment) {
         this.comment = comment;
-    }
-
-    @Override
-    public String toString() {
-        return JsonbBuilder.create().toJson(this);
     }
 }

--- a/jaxrs/sse-producer/src/main/java/org/javaee8/jaxrs/sseproducer/producer/SseResource.java
+++ b/jaxrs/sse-producer/src/main/java/org/javaee8/jaxrs/sseproducer/producer/SseResource.java
@@ -15,11 +15,13 @@ import javax.ws.rs.sse.SseEventSink;
 import org.javaee8.jaxrs.sseproducer.data.EventData;
 
 /**
+ * Produces server side events.
+ *
  * @author Daniel Contreras
  */
 @Path("sse")
 public class SseResource {
-    
+
     @Context
     private Sse sse;
 
@@ -34,25 +36,23 @@ public class SseResource {
     @Path("register")
     @Produces(MediaType.SERVER_SENT_EVENTS)
     public void register(@Context SseEventSink eventSink) {
-        
-        Jsonb jsonb = JsonbBuilder.create();
 
-        eventSink.send(sse.newEvent("INIT",new EventData("event:intialized").toString()));
+        final Jsonb json = JsonbBuilder.create();
+        eventSink.send(sse.newEvent("INIT", json.toJson(new EventData("event:intialized"))));
 
         sseBroadcaster.register(eventSink);
 
         for (int i = 0; i < 5; i++) {
 
-            sseBroadcaster.broadcast(sse.newEvent("EVENT",new EventData("event:"+i).toString()));
+            sseBroadcaster.broadcast(sse.newEvent("EVENT", json.toJson(new EventData("event:" + i))));
 
             try {
-                Thread.sleep(100);
+                Thread.sleep(10);
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }
         }
-        
-        eventSink.send(sse.newEvent("FINISH",new EventData("event:finished").toString()));
+
+        eventSink.send(sse.newEvent("FINISH", json.toJson(new EventData("event:finished"))));
     }
-    
 }

--- a/jaxrs/sse-producer/src/main/webapp/index.html
+++ b/jaxrs/sse-producer/src/main/webapp/index.html
@@ -1,9 +1,5 @@
 <!DOCTYPE html>
 <!--
-To change this license header, choose License Headers in Project Properties.
-To change this template file, choose Tools | Templates
-and open the template in the editor.
-
 @author Daniel Contreras
 -->
 <html>
@@ -20,7 +16,7 @@ and open the template in the editor.
         <button onclick="start()">Start</button>
 
         <script>
-                        
+
             function start() {
 
                 var eventSource = new EventSource("rest/sse/register");
@@ -28,7 +24,7 @@ and open the template in the editor.
 
                 eventSource.onmessage = function (event) {
                     console.log(event)
-                    var el = document.getElementById("foo"); 
+                    var el = document.getElementById("foo");
                     el.innerHTML += event.data + "<br/>";
                     el.scrollTop += 50;
                 };
@@ -36,7 +32,7 @@ and open the template in the editor.
                 eventSource.addEventListener('broadcast', function (event) {
 
                     console.log(event)
-                    var el = document.getElementById("foo"); 
+                    var el = document.getElementById("foo");
                     el.innerHTML += event.data + "lt;br/&>";
                     el.scrollTop += 50;
 

--- a/jaxrs/sse-producer/src/test/java/org/javaee8/jaxrs/sseproducer/SseResourceTest.java
+++ b/jaxrs/sse-producer/src/test/java/org/javaee8/jaxrs/sseproducer/SseResourceTest.java
@@ -1,14 +1,29 @@
 package org.javaee8.jaxrs.sseproducer;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
-import java.io.IOException;
 import java.net.URL;
-import java.util.Arrays;
 import java.util.Date;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Consumer;
+
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.sse.InboundSseEvent;
+import javax.ws.rs.sse.SseEventSource;
 
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.HttpUrlConnectorProvider;
+import org.hamcrest.Matchers;
 import org.javaee8.jaxrs.sseproducer.data.EventData;
 import org.javaee8.jaxrs.sseproducer.producer.SseResource;
 import org.javaee8.jaxrs.sseproducer.rest.RestApplication;
@@ -22,82 +37,96 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.sse.SseEventSource;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
 /**
+ * Test example for the Server-Sent Events with the Jersey JAX-RS implementation.
+ *
  * @author Daniel Contreras
+ * @author David Matějček
  */
 @RunWith(Arquillian.class)
 public class SseResourceTest {
+
+    private static final String[] EVENT_TYPES = {"INIT", "EVENT", "FINISH"};
 
     @ArquillianResource
     private URL base;
 
     private Client sseClient;
     private WebTarget target;
+    private SseEventSource eventSource;
 
-    SseEventSource eventSource;
-
-    @Deployment(testable = false)
+    @Deployment(testable = true)
     public static WebArchive createDeployment() {
-        return create(WebArchive.class)
-                .addClasses(RestApplication.class, SseResource.class, EventData.class, JsonbBuilder.class, Jsonb.class);
+        return create(WebArchive.class).addClasses(RestApplication.class, SseResource.class, EventData.class);
     }
 
+
+    /**
+     * Initializes the client, target and the eventSource used to create event consumers
+     */
     @Before
     public void setup() {
-        this.sseClient = ClientBuilder.newClient();
-        this.target = this.sseClient.target(base + "rest/sse/register");
-        eventSource = SseEventSource.target(target).build();
+        // this is needed to avoid a conflict with embedded server, that can have
+        // customized configuration and connector providers.
+        final ClientConfig configuration = new ClientConfig();
+        configuration.property(ClientProperties.CONNECT_TIMEOUT, 100);
+        configuration.property(ClientProperties.READ_TIMEOUT, 5000);
+        configuration.connectorProvider(new HttpUrlConnectorProvider());
+        this.sseClient = ClientBuilder.newClient(configuration);
+        this.target = this.sseClient.target(this.base + "rest/sse/register");
+        this.eventSource = SseEventSource.target(this.target).build();
         System.out.println("SSE Event source created........");
+        final Response response = this.target.request().get();
+        assertThat("GET response status - server is not ready", response.getStatus(),
+            Matchers.equalTo(Response.Status.OK.getStatusCode()));
     }
 
+
+    /**
+     * Closes all client resources.
+     */
     @After
     public void teardown() {
-        eventSource.close();
+        this.eventSource.close();
         System.out.println("Closed SSE Event source..");
-        sseClient.close();
+        this.sseClient.close();
         System.out.println("Closed JAX-RS client..");
     }
 
-    String[] types = {"INIT", "EVENT", "FINISH"};
 
-    @Test
+    /**
+     * Registers reaction on events, waits for events and checks their content.
+     *
+     * @throws Exception
+     */
+    @Test(timeout = 5000)
     @RunAsClient
-    public void testSSE() throws IOException {
-
-        Jsonb jsonb = JsonbBuilder.create();
-
-        System.out.println("SSE Client triggered in thread " + Thread.currentThread().getName());
-        try {
-            eventSource.register(
-                    (sseEvent)
-                    -> {
-                assertTrue(Arrays.asList(types).contains(sseEvent.getName()));
-                assertNotNull(sseEvent.readData());
-                EventData event = jsonb.fromJson(sseEvent.readData(), EventData.class);
-                assertThat(event.getTime(), instanceOf(Date.class));
-                assertNotNull(event.getId());
-                assertTrue(event.getComment().contains("event:"));
-                System.out.println("\nSSE Event received :: " + event.toString() +"\n");
-                
-            },
-                    (e) -> e.printStackTrace());
-
-            eventSource.open();
-            Thread.sleep(1500);
-        } catch (Exception e) {
-            System.out.println("Error on SSE Test");
-            System.out.println(e.getMessage());
+    public void testSSE() throws Exception {
+        final Queue<Throwable> asyncExceptions = new ConcurrentLinkedQueue<>();
+        final Queue<EventData> receivedEvents = new ConcurrentLinkedQueue<>();
+        // jsonb is thread safe!
+        final Jsonb jsonb = JsonbBuilder.create();
+        final Consumer<InboundSseEvent> onEvent = (sseEvent) -> {
+            assertThat("event type", sseEvent.getName(), Matchers.isOneOf(EVENT_TYPES));
+            final String data = sseEvent.readData();
+            System.out.println("Data received as string:\n" + data);
+            assertNotNull("data received as string", data);
+            final EventData event = jsonb.fromJson(data, EventData.class);
+            receivedEvents.add(event);
+            assertThat("event.time", event.getTime(), instanceOf(Date.class));
+            assertNotNull("event.id", event.getId());
+            assertThat("event.comment", event.getComment(), Matchers.containsString("event:"));
+        };
+        this.eventSource.register(onEvent, asyncExceptions::add);
+        System.out.println("Server Side Events Client registered in the test thread.");
+        // following line starts acceptation of events.
+        this.eventSource.open();
+        // don't end the test until we have all events or timeout or error comes.
+        // this is not an obvious implementation, we only need to hold the test until all events
+        // are asynchronously processed.
+        while (receivedEvents.size() <= 5 && asyncExceptions.isEmpty()) {
+            Thread.sleep(10L);
         }
-
+        assertThat("receiver exceptions", asyncExceptions, Matchers.emptyIterable());
     }
-
 }


### PR DESCRIPTION
- test was successful if run against remote servers, but failed with embedded
  The cause was that the default server's private embedded payara provider is
  incompatible with the jerseys's
- solution: configure the jersey client to be independent on server settings/impl
- also done some cleanup and comments
- the test is faster now and has timeout set (hangouts were possible)
- no asserts lost now (try/catch/stacktrace replaced with collecting junit
  exceptions from each event processing and asserting that all assertions passed
  and no exception was thrown)