### PR TITLE
Fixed #28 ConstraintViolationTest results are not dependent on locale…

### DIFF
--- a/validation/constraints/src/test/java/org/javaee8/validation/ConstraintViolationTest.java
+++ b/validation/constraints/src/test/java/org/javaee8/validation/ConstraintViolationTest.java
@@ -14,6 +14,7 @@ import javax.validation.Validator;
 import javax.validation.groups.Default;
 import java.time.*;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 
@@ -28,7 +29,14 @@ import static org.junit.Assert.assertThat;
 public class ConstraintViolationTest {
 
     private Validator validator;
-    
+
+    static {
+        // prevent to use translated messages which we compare in test;
+        // translation language depends on the locale.
+        Locale.setDefault(Locale.US);
+    }
+
+
     @Deployment
     public static WebArchive deploy() {
         return create(WebArchive.class)


### PR DESCRIPTION
… any more

- default locale is set to US before the test