### PR TITLE
Add Thorntail support

### DIFF
--- a/cdi/dynamic-bean/src/test/java/org/javaee8/cdi/dynamic/bean/DynamicBeanTest.java
+++ b/cdi/dynamic-bean/src/test/java/org/javaee8/cdi/dynamic/bean/DynamicBeanTest.java
@@ -29,7 +29,7 @@ public class DynamicBeanTest {
                     create(JavaArchive.class)
                         .addClasses(CdiExtension.class, MyBean.class, MyBeanImpl.class)
                         .addAsResource("META-INF/services/javax.enterprise.inject.spi.Extension"))
-                .addAsManifestResource("beans.xml");
+                .addAsWebInfResource("beans.xml");
     }
 
     @Inject

--- a/jpa/dynamic-tx/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/jpa/dynamic-tx/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,8 @@
+<jboss-deployment-structure>
+  <deployment>
+    <dependencies>
+      <!-- https://issues.jboss.org/browse/WFLY-11629  -->
+      <module name="org.jboss.jts" services="export"/>
+    </dependencies>    
+  </deployment>  
+</jboss-deployment-structure>

--- a/jpa/dynamic-tx/src/test/java/org/javaee8/jpa/dynamic/tx/DynamicTXTest.java
+++ b/jpa/dynamic-tx/src/test/java/org/javaee8/jpa/dynamic/tx/DynamicTXTest.java
@@ -4,6 +4,8 @@ import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+import java.io.File;
+
 import javax.inject.Inject;
 
 import org.hamcrest.Matchers;
@@ -36,7 +38,8 @@ public class DynamicTXTest {
                 .addPackage(
                     TransactionLiteral.class.getPackage())
                 .addAsResource(
-                    "META-INF/persistence.xml");
+                    "META-INF/persistence.xml")
+                .addAsWebInfResource(new File("src/main/webapp/WEB-INF/jboss-deployment-structure.xml"));
     }
 
     @Test

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -23,4 +23,15 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>thorntail</id>
+            <dependencies>
+                <dependency>
+                    <groupId>com.h2database</groupId>
+                    <artifactId>h2</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/jsf/extensionless-mapping/src/main/java/org/javaee8/cdi/dynamic/bean/MappingInit.java
+++ b/jsf/extensionless-mapping/src/main/java/org/javaee8/cdi/dynamic/bean/MappingInit.java
@@ -2,34 +2,47 @@ package org.javaee8.cdi.dynamic.bean;
 
 import static javax.faces.application.ViewVisitOption.RETURN_AS_MINIMAL_IMPLICIT_OUTCOME;
 
+import java.util.Map;
+
+import javax.faces.application.Application;
 import javax.faces.context.FacesContext;
+import javax.faces.event.AbortProcessingException;
+import javax.faces.event.SystemEvent;
+import javax.faces.event.SystemEventListener;
 import javax.faces.webapp.FacesServlet;
-import javax.servlet.ServletContextEvent;
-import javax.servlet.ServletContextListener;
-import javax.servlet.annotation.WebListener;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletRegistration;
 
 /**
  * 
  * @author Arjan Tijms
  */
-@WebListener
-public class MappingInit implements ServletContextListener {
+public class MappingInit implements SystemEventListener {
     
-    @Override
-    public void contextInitialized(ServletContextEvent sce) {
-        FacesContext context = FacesContext.getCurrentInstance();
+ 
+	@Override
+	public void processEvent(SystemEvent event) throws AbortProcessingException {
+		
+		FacesContext facesContext = event.getFacesContext();
+        ServletContext sc = (ServletContext) facesContext.getExternalContext().getContext();
         
-        sce.getServletContext()
-           .getServletRegistrations()
-           .values()
-           .stream()
-           .filter(e -> e.getClassName().equals(FacesServlet.class.getName()))
-           .findAny()
-           .ifPresent(
-               reg -> context.getApplication()
-                             .getViewHandler()
-                             .getViews(context, "/", RETURN_AS_MINIMAL_IMPLICIT_OUTCOME)
-                             .forEach(e -> reg.addMapping(e)));
+        if (Boolean.valueOf((String) sc.getAttribute("mappingsAdded"))) {
+        	return;
+        }
+
+        Map<String, ? extends ServletRegistration> servletRegistrations = (Map<String, ? extends ServletRegistration>) sc.getAttribute("mappings");
+        
+        if (servletRegistrations == null) {
+        	return;
+        }
+
+        MappingServletContextListener.addServletMappings(servletRegistrations, facesContext);
     }
+		
+
+	@Override
+	public boolean isListenerForSource(Object source) {
+		return source instanceof Application;
+	}
 
 }

--- a/jsf/extensionless-mapping/src/main/java/org/javaee8/cdi/dynamic/bean/MappingServletContextListener.java
+++ b/jsf/extensionless-mapping/src/main/java/org/javaee8/cdi/dynamic/bean/MappingServletContextListener.java
@@ -1,0 +1,44 @@
+package org.javaee8.cdi.dynamic.bean;
+
+import static javax.faces.application.ViewVisitOption.RETURN_AS_MINIMAL_IMPLICIT_OUTCOME;
+
+import java.util.Map;
+
+import javax.faces.application.Application;
+import javax.faces.context.FacesContext;
+import javax.faces.webapp.FacesServlet;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.ServletRegistration;
+import javax.servlet.annotation.WebListener;
+
+@WebListener
+public class MappingServletContextListener implements ServletContextListener {
+
+	@Override
+	public void contextInitialized(ServletContextEvent sce) {
+		ServletContext sc =  sce.getServletContext();
+
+		sc.setAttribute("mappings", sce.getServletContext().getServletRegistrations());
+		
+		FacesContext facesContext = FacesContext.getCurrentInstance();
+		if (facesContext == null) {
+			//It 's possible that JSF isn't available at this time depending on JSF implementation and Java server container
+			return;
+		}
+        
+        addServletMappings(sc.getServletRegistrations(), facesContext);
+        
+        //Add a flag to not add the mappings again later in MappingInit
+        sc.setAttribute("mappingsAdded", "true");
+	}
+
+	public static void addServletMappings(Map<String, ? extends ServletRegistration> servletRegistrations, FacesContext facesContext) {
+        servletRegistrations.values().stream().filter(e -> e.getClassName().equals(FacesServlet.class.getName()))
+        .findAny()
+        .ifPresent(reg -> facesContext.getApplication().getViewHandler().getViews(
+        		facesContext, "/", RETURN_AS_MINIMAL_IMPLICIT_OUTCOME).forEach(e -> reg.addMapping(e)));
+	}
+
+}

--- a/jsf/extensionless-mapping/src/main/webapp/WEB-INF/faces-config.xml
+++ b/jsf/extensionless-mapping/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,0 +1,12 @@
+<faces-config xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_3.xsd"
+    version="2.3">
+
+    <application>
+        <system-event-listener>        
+            <system-event-listener-class>org.javaee8.cdi.dynamic.bean.MappingInit</system-event-listener-class>
+            <system-event-class>javax.faces.event.PostConstructApplicationEvent</system-event-class>
+        </system-event-listener>
+    </application>
+</faces-config>

--- a/jsf/extensionless-mapping/src/test/java/org/javaee8/cdi/dynamic/bean/ExtensionlessMappingTest.java
+++ b/jsf/extensionless-mapping/src/test/java/org/javaee8/cdi/dynamic/bean/ExtensionlessMappingTest.java
@@ -47,11 +47,12 @@ public class ExtensionlessMappingTest {
     public static WebArchive deploy() {
         WebArchive war = 
             create(WebArchive.class)
-                .addClasses(MappingInit.class, ApplicationInit.class)
+                .addClasses(MappingInit.class, ApplicationInit.class, MappingServletContextListener.class)
                 .addAsWebResource(new File("src/main/webapp/foo.xhtml"))
                 .addAsWebResource(new File("src/main/webapp/bar.xhtml"))
                 .addAsWebResource(new File("src/main/webapp/sub/bar.xhtml"), "/sub/bar.xhtml")
-                .addAsManifestResource("beans.xml");
+                .addAsWebInfResource("beans.xml")
+                .addAsWebInfResource(new File("src/main/webapp/WEB-INF/faces-config.xml"));
         
         System.out.println("War to be deployed contains: \n" + war.toString(true));
         

--- a/jsonb/mapping/src/main/java/org/javaee8/jsonb/mapping/controller/PersonController.java
+++ b/jsonb/mapping/src/main/java/org/javaee8/jsonb/mapping/controller/PersonController.java
@@ -3,9 +3,11 @@ package org.javaee8.jsonb.mapping.controller;
 import org.javaee8.jsonb.mapping.domain.Person;
 import java.util.Arrays;
 import java.util.List;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 /**
  * 
  * @author Gaurav Gupta
@@ -20,6 +22,7 @@ public class PersonController {
      *
      */
     @GET
+    @Produces(MediaType.APPLICATION_JSON)
     public List<Person> getAllPeople() {
         Person person1 = new Person();
         person1.setName("Ondrej");

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <payara.micro.version>5.183</payara.micro.version>
         <glassfish.version>5.0</glassfish.version>
         <tomcat.version>9.0.12</tomcat.version>
+        <thorntail.version>2.3.0.Final</thorntail.version>
     </properties>
 
     <repositories>
@@ -322,11 +323,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>3.0.2</version>
-            </plugin>
-            <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-maven-plugin</artifactId>
-                <version>1.0.2.Final</version>
             </plugin>
         </plugins>
     </build>
@@ -843,6 +839,55 @@
             </build>
         </profile>
 
+        <!-- ### THORNTAIL ### -->
+
+        <profile>
+            <id>thorntail</id>
+
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.thorntail</groupId>
+                        <artifactId>bom</artifactId>
+                        <version>${thorntail.version}</version>
+                        <scope>import</scope>
+                        <type>pom</type>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+    
+            <dependencies>
+    
+                <!-- Java EE based client dependencies to contact a server via 
+                    WebSocket or REST -->
+                <dependency>
+                    <groupId>fish.payara.arquillian</groupId>
+                    <artifactId>payara-client-ee8</artifactId>
+                </dependency>
+    
+                <dependency>
+                    <groupId>io.thorntail</groupId>
+                    <artifactId>arquillian</artifactId>
+                    <scope>test</scope>
+                </dependency>
+    
+            </dependencies>
+    
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <!-- Uncomment to debug -->
+                                <!--<thorntail.debug.port>8000</thorntail.debug.port> -->
+                                <arquillian.xml>arquillian-thorntail.xml</arquillian.xml>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
 
 
         <!-- Activate this profile to download javadoc and sources jars.

--- a/security/dynamic-rememberme/src/test/java/org/javaee8/security/dynamic/rememberme/DynamicRemembermeTest.java
+++ b/security/dynamic-rememberme/src/test/java/org/javaee8/security/dynamic/rememberme/DynamicRemembermeTest.java
@@ -47,7 +47,8 @@ public class DynamicRemembermeTest {
                     Servlet.class
                 )
                 .addPackage(
-                    RememberMeAnnotationLiteral.class.getPackage());
+                    RememberMeAnnotationLiteral.class.getPackage())
+                .addAsWebInfResource("jboss-web.xml");
     }
 
     @Before

--- a/security/dynamic-rememberme/src/test/resources/jboss-web.xml
+++ b/security/dynamic-rememberme/src/test/resources/jboss-web.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<jboss-web>
+    <!-- JASPIC activation for Wildfly. -->
+    <!-- See https://arjan-tijms.omnifaces.org/2015/08/activating-jaspic-in-jboss-wildfly.html -->
+    <security-domain>jaspitest</security-domain>
+</jboss-web>

--- a/security/jwt/src/test/java/org/javaee8/security/jwt/JwtTest.java
+++ b/security/jwt/src/test/java/org/javaee8/security/jwt/JwtTest.java
@@ -83,7 +83,8 @@ public class JwtTest {
                 .addPackage(JWTCredential.class.getPackage())
                 .addAsLibraries(jjwtFiles)
                 .setWebXML("web.xml")
-                .addAsWebInfResource("beans.xml");
+                .addAsWebInfResource("beans.xml")
+                .addAsWebInfResource("jboss-web.xml");
     }
 
     @Before

--- a/security/jwt/src/test/resources/jboss-web.xml
+++ b/security/jwt/src/test/resources/jboss-web.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<jboss-web>
+    <!-- JASPIC activation for Wildfly. -->
+    <!-- See https://arjan-tijms.omnifaces.org/2015/08/activating-jaspic-in-jboss-wildfly.html -->
+    <security-domain>jaspitest</security-domain>
+</jboss-web>

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -13,8 +13,8 @@
     <name>Java EE 8 Samples: Security</name>
 
     <modules>
-        	<module>dynamic-rememberme</module>
-                <module>jwt</module>
+            <module>dynamic-rememberme</module>
+            <module>jwt</module>
     </modules>
 
     <dependencies>

--- a/servlet/http2/pom.xml
+++ b/servlet/http2/pom.xml
@@ -53,8 +53,8 @@
                 <jdk>1.8</jdk>
             </activation>
             <properties>
-                <!-- default is the newest possible, supports 8u161 to 8u181 -->
-                <alpn.version>8.1.12.v20180117</alpn.version>
+                <!-- default is the newest possible, supports 8u161 to 8u191 -->
+                <alpn.version>8.1.13.v20181017</alpn.version>
                 <bootclasspathPrefix>
                     ${settings.localRepository}/org/mortbay/jetty/alpn/alpn-boot/${alpn.version}/alpn-boot-${alpn.version}.jar
                 </bootclasspathPrefix>

--- a/servlet/http2/src/test/java/org/javaee8/servlet/http2/Http2Test.java
+++ b/servlet/http2/src/test/java/org/javaee8/servlet/http2/Http2Test.java
@@ -38,9 +38,10 @@ public class Http2Test {
 
     @Deployment
     public static WebArchive createDeployment() {
-        final WebArchive war = create(WebArchive.class).addPackages(true, "org.javaee8.servlet.http2")
+        final WebArchive war = create(WebArchive.class).addClasses(Servlet.class)
                 .addAsWebResource(new File("src/main/webapp/images/payara-logo.jpg"), "images/payara-logo.jpg")
-                .addAsWebInfResource(new File("src/main/webapp/WEB-INF/web.xml"));
+                .addAsWebInfResource(new File("src/main/webapp/WEB-INF/web.xml"))
+                .addAsResource("project-defaults.yml"); // only for Thormtail;
         System.out.println("War file content: \n" + war.toString(true));
         return war;
     }

--- a/servlet/http2/src/test/resources/project-defaults.yml
+++ b/servlet/http2/src/test/resources/project-defaults.yml
@@ -1,0 +1,8 @@
+thorntail:
+  undertow:
+    servers:
+      default-server:
+        http-listeners:
+          default:
+            # in Thorntail, HTTP/2 is by default only enabled for the HTTPS listener
+            enable-http2: true

--- a/servlet/mapping/src/main/java/org/javaee8/servlet/mapping/Servlet.java
+++ b/servlet/mapping/src/main/java/org/javaee8/servlet/mapping/Servlet.java
@@ -28,11 +28,13 @@ public class Servlet extends HttpServlet {
                 .append("Mapping match:")
                 .append(mapping.getMappingMatch().name())
                 .append("\n")
-                .append("Match value:")
+                .append("Match value:'")
                 .append(mapping.getMatchValue())
+                .append("'")
                 .append("\n")
-                .append("Pattern:")
-                .append(mapping.getPattern());
+                .append("Pattern:'")
+                .append(mapping.getPattern())
+                .append("'");
     }
  
 }

--- a/servlet/mapping/src/test/java/org/javaee8/servlet/mapping/ServletMappingTest.java
+++ b/servlet/mapping/src/test/java/org/javaee8/servlet/mapping/ServletMappingTest.java
@@ -59,8 +59,8 @@ public class ServletMappingTest {
         System.out.println("\nContent for `"+ base + "path/foo" + "` :\n" + content + "\n");
         
         assertTrue(content.contains("Mapping match:" + MappingMatch.PATH.name()));
-        assertTrue(content.contains("Match value:foo"));
-        assertTrue(content.contains("Pattern:/path/*"));
+        assertTrue(content.contains("Match value:'foo'"));
+        assertTrue(content.contains("Pattern:'/path/*'"));
     }
 
     @Test
@@ -74,8 +74,8 @@ public class ServletMappingTest {
         System.out.println("\nContent for `"+ base + "foo.ext" + "` :\n" + content + "\n");
         
         assertTrue(content.contains("Mapping match:" + MappingMatch.EXTENSION.name()));
-        assertTrue(content.contains("Match value:foo"));
-        assertTrue(content.contains("Pattern:*.ext"));
+        assertTrue(content.contains("Match value:'foo'"));
+        assertTrue(content.contains("Pattern:'*.ext'"));
     }
     
     @Test
@@ -89,8 +89,8 @@ public class ServletMappingTest {
         System.out.println("\nContent for `"+ base + "` :\n" + content + "\n");
         
         assertTrue(content.contains("Mapping match:" + MappingMatch.CONTEXT_ROOT.name()));
-        assertTrue(content.contains("Match value:"));
-        assertTrue(content.contains("Pattern:/"));
+        assertTrue(content.contains("Match value:''"));
+        assertTrue(content.contains("Pattern:''"));
     }
     
     @Test
@@ -104,8 +104,8 @@ public class ServletMappingTest {
         System.out.println("\nContent for `"+ base + "doesnotexist" + "` :\n" + content + "\n");
         
         assertTrue(content.contains("Mapping match:" + MappingMatch.DEFAULT.name()));
-        assertTrue(content.contains("Match value:doesnotexist"));
-        assertTrue(content.contains("Pattern:/"));
+        assertTrue(content.contains("Match value:''"));
+        assertTrue(content.contains("Pattern:'/'"));
     }
     
     @Test
@@ -119,8 +119,8 @@ public class ServletMappingTest {
         System.out.println("\nContent for `"+ base + "exact" + "` :\n" + content + "\n");
         
         assertTrue(content.contains("Mapping match:" + MappingMatch.EXACT.name()));
-        assertTrue(content.contains("Match value:exact"));
-        assertTrue(content.contains("Pattern:/exact"));
+        assertTrue(content.contains("Match value:'exact'"));
+        assertTrue(content.contains("Pattern:'/exact'"));
     }
     
 

--- a/test-utils/src/main/resources/arquillian-thorntail.xml
+++ b/test-utils/src/main/resources/arquillian-thorntail.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://jboss.org/schema/arquillian" xsi:schemaLocation="http://jboss.org/schema/arquillian
+    http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <!--
+      - must be in a separate file because in-container tests need to use Swarm's DaemonProtocol,
+      - but arquillian.xml sets the default protocol to "Servlet 3.0" and there's no way to override that
+      - (see https://issues.jboss.org/browse/ARQ-579)
+      -->
+    <container qualifier="thorntail" default="true">
+        <configuration>
+            <property name="host">localhost</property>
+            <property name="port">${thorntail.arquillian.daemon.port:12345}</property>
+        </configuration>
+    </container>
+
+</arquillian>


### PR DESCRIPTION
So, after release of 2.3.0.Final, I can push this pull request.

There are some changes I want to highlight:
- In Extensionless Mapping, there is a ServletContexListener (MappingInit), that makes usage of FacesContext.getCurrentInstance(). Depending if  JSF Mojarra's own ServletContextListener (ConfigureListener), where all environment is setup, is invoked before project's custom ServletContextListener, this will work or will throw a NullPointerException. In order to avoid this, I had to order both listeners explicitely in web.xml, so JSF initialization comes first always.
- In Servlet Mapping test: I made two changes that now makes test failing in Payara:
   -For DEFAULT servlet, match value should be empty, instead of the wrong requested resource. This seems clear in javadoc examples here: [https://javaee.github.io/javaee-spec/javadocs/javax/servlet/http/HttpServletMapping.html](url)
   -For CONTEXT_ROOT servlet, javadoc table example was clear too, except there were some wrong statement in getPattern for DEFAULT servlet, but this should be fixed under: https://github.com/eclipse-ee4j/servlet-api/issues/233 
 
/cc @Ladicek