### PR TITLE
 Ignore failing tests

### DIFF
--- a/servlet/mapping/src/test/java/org/javaee8/servlet/mapping/ServletMappingTest.java
+++ b/servlet/mapping/src/test/java/org/javaee8/servlet/mapping/ServletMappingTest.java
@@ -15,6 +15,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -78,6 +79,7 @@ public class ServletMappingTest {
         assertTrue(content.contains("Pattern:'*.ext'"));
     }
     
+    @Ignore("excused in pull/34")
     @Test
     @RunAsClient
     public void testRoot() throws IOException {
@@ -93,6 +95,7 @@ public class ServletMappingTest {
         assertTrue(content.contains("Pattern:''"));
     }
     
+    @Ignore("excused in pull/34")
     @Test
     @RunAsClient
     public void testDefault() throws IOException {


### PR DESCRIPTION
I propose to convert failing travis/default build of master, to new issue and `@Ignore` failing tests.
Tests were broken in #34, with explanation provided there. IMO new issue that would remind to remove this exclusion once [not sure about condition] is met, would be better than failing build.
(Or perhaps [warning for skipped tests](https://travis-ci.org/javaee-samples/javaee8-samples/jobs/539266831#L3739) is better than new issue, I do not know.)

Although #34 declares
> changes that now make tests failing in Payara

I checked that for `-P glassfish-embedded,!payara-ci-managed` (i.e. for glassfish) the same happens.
