### PR TITLE
Fix http2 test

### DIFF
--- a/servlet/http2/src/test/java/org/javaee8/servlet/http2/Http2Test.java
+++ b/servlet/http2/src/test/java/org/javaee8/servlet/http2/Http2Test.java
@@ -67,7 +67,7 @@ public class Http2Test {
     @Test(timeout = 10000L)
     @RunAsClient
     public void testHttp2ControlGroup() throws Exception {
-        Response response = testUri(new URI("https://http2.akamai.com/"));
+        Response response = testUri(new URI("https://linkedin.com/"));
         assertThat("myproto header", response.getHeaderString("myproto"), Matchers.equalTo("h2"));
     }
 


### PR DESCRIPTION
The test was pointing at https://http2.akamai.com/ to receive a response using the protocol http2. But that website now returns a response using http1.1, so the test is now failing. 
This fix only changes the target to point at linkedin, using http2 by default.